### PR TITLE
feat: case insensitive header parsing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,5 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+# This file is responsible for configuring your application and its dependencies.
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
@@ -20,11 +19,3 @@ use Mix.Config
 #
 #     config :logger, level: :info
 #
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
-#     import_config "#{Mix.env}.exs"

--- a/lib/mail/parsers/rfc_2822.ex
+++ b/lib/mail/parsers/rfc_2822.ex
@@ -209,7 +209,7 @@ defmodule Mail.Parsers.RFC2822 do
     [name, body] = String.split(header, ":", parts: 2)
     key = String.downcase(name)
     decoded = parse_encoded_word(body)
-    headers = put_header(message.headers, key, parse_header_value(name, decoded))
+    headers = put_header(message.headers, key, parse_header_value(key, decoded))
     message = %{message | headers: headers}
     parse_headers(message, tail)
   end
@@ -235,36 +235,36 @@ defmodule Mail.Parsers.RFC2822 do
   defp parse_header_value(key, "\t" <> value),
     do: parse_header_value(key, value)
 
-  defp parse_header_value("To", value),
+  defp parse_header_value("to", value),
     do: parse_recipient_value(value)
 
-  defp parse_header_value("CC", value),
+  defp parse_header_value("cc", value),
     do: parse_recipient_value(value)
 
-  defp parse_header_value("From", value),
+  defp parse_header_value("from", value),
     do:
       parse_recipient_value(value)
       |> List.first()
 
-  defp parse_header_value("Reply-To", value),
+  defp parse_header_value("reply-to", value),
     do:
       parse_recipient_value(value)
       |> List.first()
 
-  defp parse_header_value("Date", timestamp),
+  defp parse_header_value("date", timestamp),
     do: erl_from_timestamp(timestamp)
 
-  defp parse_header_value("Received", value),
+  defp parse_header_value("received", value),
     do: parse_received_value(value)
 
-  defp parse_header_value("Content-Type", value) do
+  defp parse_header_value("content-type", value) do
     case parse_structured_header_value(value) do
       [_ | _] = header -> header
       <<value::binary>> -> [value, {"charset", "us-ascii"}]
     end
   end
 
-  defp parse_header_value("Content-Disposition", value),
+  defp parse_header_value("content-disposition", value),
     do: parse_structured_header_value(value)
 
   defp parse_header_value(_key, value),

--- a/test/mail/parsers/rfc_2822_test.exs
+++ b/test/mail/parsers/rfc_2822_test.exs
@@ -737,6 +737,28 @@ defmodule Mail.Parsers.RFC2822Test do
     assert message.body == "first line\r\nsecond line\r\nbye"
   end
 
+  test "parses multipart nodes with wrong capitalization in content-type" do
+    message =
+      parse_email("""
+      To: user@example.com
+      From: me@example.com
+      Subject: hello, world
+      Content-type: multipart/mixed;
+      \tboundary="B_3741238731_409882693"
+
+      --B_3741238731_409882693
+      Content-Type: text/plain
+      Content-Transfer-Encoding: 7bit
+
+      hello, world
+
+      --B_3741238731_409882693--
+      """)
+
+    assert %Mail.Message{multipart: true, parts: [text_message_part]} = message
+    assert text_message_part.body == "hello, world"
+  end
+
   defp parse_email(email),
     do: email |> convert_crlf |> Mail.Parsers.RFC2822.parse()
 


### PR DESCRIPTION
We receive the `Content-Type` header with non-standard capitalization sometimes. This violates [rfc2616](https://www.rfc-editor.org/rfc/rfc2616#section-14.17), but unfortunately we still need to correctly parse those messsages.

e.g.:
```elixir
message = """
To: user@example.com\r
From: me@example.com\r
Subject: hello, world\r
Content-type: multipart/mixed;\r
\tboundary="B_3741238731_409882693"\r
\r
--B_3741238731_409882693\r
Content-Type: text/plain\r
Content-Transfer-Encoding: 7bit\r
\r
hello, world\r
\r
--B_3741238731_409882693--\r
"""

Mail.Parsers.RFC2822.parse(message)
```

the output is

```elixir
%Mail.Message{
  body: "--B_3741238731_409882693\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: 7bit\r\n\r\nhello, world\r\n\r\n--B_3741238731_409882693--",
  headers: %{
    "content-type" => "multipart/mixed;\tboundary=\"B_3741238731_409882693\"",
    "from" => "me@example.com",
    "subject" => "hello, world",
    "to" => ["user@example.com"]
  },
  multipart: false,
  parts: []
}
```

where `multipart` is `false`, `content-type` contains multipart's boundary and the body has a lot of data that now we are not able to handle correctly